### PR TITLE
Upgraded Terraform to 0.1.1

### DIFF
--- a/workloads/nrotelk8s/terraform/maint.tf
+++ b/workloads/nrotelk8s/terraform/maint.tf
@@ -1,7 +1,7 @@
 ### New Relic
 
 module "nrotelk8s" {
-  source = "github.com/newrelic-experimental/monitoring-kubernetes-with-opentelemetry.git?ref=newrelic-monitoring-0.1.0/monitoring/terraform"
+  source = "github.com/newrelic-experimental/monitoring-kubernetes-with-opentelemetry.git?ref=newrelic-monitoring-0.1.1/monitoring/terraform"
 
   NEW_RELIC_ACCOUNT_ID = var.NEW_RELIC_ACCOUNT_ID
   NEW_RELIC_API_KEY    = var.NEW_RELIC_API_KEY


### PR DESCRIPTION
## Changes

- Terraform module for OTel K8s monitoring is upgraded to `0.1.1`