### PR TITLE
Scaled down VMs

### DIFF
--- a/aks/terraform/00_main.tf
+++ b/aks/terraform/00_main.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.69.0"
+      version = ">=3.75.0"
     }
   }
 

--- a/aks/terraform/05_kubernetes.tf
+++ b/aks/terraform/05_kubernetes.tf
@@ -43,7 +43,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "general" {
   }
 
   enable_auto_scaling = true
-  node_count          = 3
-  min_count           = 3
-  max_count           = 5
+  node_count          = 1
+  min_count           = 1
+  max_count           = 3
 }


### PR DESCRIPTION
## Changes

- Azure RM Terraform provider is upgraded to `3.75.0`.
- General node pool VMs are scaled down to `2`.